### PR TITLE
 Use brightwheel config for pgbouncer 1.7.2 tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Heroku buildpack: pgbouncer
+# Brightwheel buildpack: pgbouncer
+
+This is a fork of the heroku buildpack - pgbouncer [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that allows us to run pgbouncer and NOT stunnel in a dyno alongside our app.
+
+We forked the heroku buildpack because we want to use *verify-full* ssl mode on a new RDS instance. The heroku-buildpack uses stunnel (https://linux.die.net/man/8/stunnel) to enforce SSL, but as of pgbouncer 1.7.2, stunnel is not required to establish SSL connections to RDS.
+
+# Heroku Buildpack - Pgbouncer
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that
 allows one to run pgbouncer and stunnel in a dyno alongside application code.

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ function package_download() {
   location="$1"
 
   mkdir -p $location
-  package="https://github.com/BetterWorks/heroku-buildpack-pgbouncer/raw/master/support/pgbouncer-1.7.2.tgz"
+  package="https://github.com/brightwheel/heroku-buildpack-pgbouncer/raw/master/support/pgbouncer-1.7.2.tgz"
   curl $package -L -s -o - | tar xzf - -C $location
 }
 

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,7 @@ function package_download() {
 # vendor directories
 VENDORED_PGBOUNCER="vendor/pgbouncer"
 
+echo "Using Brightwheel PGBouncer Buildpack"
 # vendor pgbouncer into the slug
 PATH="$BUILD_DIR/$VENDORED_PGBOUNCER/bin:$PATH"
 echo "-----> Fetching and vendoring pgbouncer into slug"

--- a/support/pgbouncer-build
+++ b/support/pgbouncer-build
@@ -3,7 +3,7 @@ set -e
 PGBOUNCER_VERSION=${PGBOUNCER_VERSION-1.7}
 STUNNEL_VERSION=${STUNNEL_VERSION-5.28}
 
-pgbouncer_tarball_url=https://pgbouncer.github.io/downloads/files/${PGBOUNCER_VERSION}/pgbouncer-${PGBOUNCER_VERSION}.tar.gz
+pgbouncer_tarball_url=https://s3.amazonaws.com/brightwheel-binaries/pgbouncer-${PGBOUNCER_VERSION}.tar.gz
 stunnel_tarball_url=https://www.stunnel.org/downloads/stunnel-${STUNNEL_VERSION}.tar.gz
 
 echo "Downloading $pgbouncer_tarball_url"

--- a/support/pgbouncer-build
+++ b/support/pgbouncer-build
@@ -4,7 +4,7 @@ PGBOUNCER_VERSION=${PGBOUNCER_VERSION-1.7}
 STUNNEL_VERSION=${STUNNEL_VERSION-5.28}
 
 pgbouncer_tarball_url=https://s3.amazonaws.com/brightwheel-binaries/pgbouncer-${PGBOUNCER_VERSION}.tar.gz
-stunnel_tarball_url=https://www.stunnel.org/downloads/stunnel-${STUNNEL_VERSION}.tar.gz
+stunnel_tarball_url=https://s3.amazonaws.com/brightwheel-binaries/stunnel-${STUNNEL_VERSION}.tar.gz
 
 echo "Downloading $pgbouncer_tarball_url"
 curl -L $pgbouncer_tarball_url | tar xzv


### PR DESCRIPTION
### Description 

##### Why are we using this buildpack and not the official Heroku one? (https://github.com/heroku/heroku-buildpack-pgbouncer)

As we move to RDS, we want to ensure that all communication between our app servers and our database is encrypted. In order to do that, we want to use SSL mode: `verify-full` on our RDS instances. 

SSL mode `verify-full` requires that we provide a `.pem` file in order to connect to the database and execute queries. Each application dyno will have the `.pem` file  on it in order to connect to the database. 

#### That sounds great, but I still don't understand why we need a new buildpack? 

The heroku official pgbouncer buildpack uses stunnel (https://linux.die.net/man/8/stunnel) as an SSL tunnel in order to connect to databases. As of pgbouncer 1.7.2, stunnel is no longer needed to connect from pgbouncer to a database via SSL. 

This buildpack removes stunnel as a dependency and uses pgbouncer's built in configuration (https://pgbouncer.github.io/config.html) `server_tls_mode` to connect to RDS via SSL. 

Since this buildpack was forked from BetterWorks, this PR removes the BetterWorks pgbouncer 1.7.2 tarball as a dependency and moves the link to the brightwheel tarball instead. 
